### PR TITLE
Fixed issue with cell merges ruining offset spans.

### DIFF
--- a/dashtable/data2rst/cell/merge_cells.py
+++ b/dashtable/data2rst/cell/merge_cells.py
@@ -25,7 +25,8 @@ def merge_cells(cell1, cell2, direction):
 
     if direction == "RIGHT":
         for i in range(len(cell1_lines)):
-            cell1_lines[i] = cell1_lines[i] + cell2_lines[i][1::]
+            #cell1_lines[i] = cell1_lines[i] + cell2_lines[i][1::]
+            cell1_lines[i] = merge_line(cell1_lines[i], cell2_lines[i])
         cell1.text = "\n".join(cell1_lines)
         cell1.column_count += cell2.column_count
 
@@ -52,10 +53,19 @@ def merge_cells(cell1, cell2, direction):
 
     elif direction == "LEFT":
         for i in range(len(cell1_lines)):
-            cell1_lines[i] = cell2_lines[i][0:-1] + cell1_lines[i]
+            #cell1_lines[i] = cell2_lines[i][0:-1] + cell1_lines[i]
+            cell1_lines[i] = merge_line(cell2_lines[i], cell2_lines[i])
         cell1.text = "\n".join(cell1_lines)
         cell1.column_count += cell2.column_count
         cell1.row = cell2.row
         cell1.column = cell2.column
 
 
+def merge_line(line1, line2):
+    line1_last_chr = line1[-1]
+    line2_first_chr = line2[0]
+    if '+' in [line1_last_chr, line2_first_chr]:
+        middle_chr = '+'
+    else:
+        middle_chr = line1_last_chr
+    return line1[:-1] + middle_chr + line2[1:]

--- a/tests/test_rstspan.py
+++ b/tests/test_rstspan.py
@@ -1,0 +1,41 @@
+import unittest
+
+from dashtable import data2rst, grid2data
+
+class TestSpans(unittest.TestCase):
+    def setUp(self) -> None:
+        self.span_table1 = '''\
++-----+--------+-------+
+| 0,0 | 0,1    | 0,2   |
++=====+========+=======+
+| 1,0 | 1,1    | 1,2   |
++-----+--------+-------+
+| 2,0 | 2,1        2,2 |
+|     |                |
++-----+ 3,1        3,2 |
+| 3,0 |                |
+|     +--------+-------+
+| 4,0 | 4,1    | 4,2   |
++-----+--------+-------+'''
+
+        self.table1, self.spans1, self.header1 = grid2data(self.span_table1)
+
+        self.span_table2 = data2rst(self.table1, self.spans1, self.header1)
+        self.table2, self.spans2, self.header2 = grid2data(self.span_table2)
+
+    def test_table_parse(self):
+        self.assertMultiLineEqual(self.span_table1, self.span_table2, "Tables' RST do not match.")
+
+    def test_table_contents(self):
+        self.assertEqual(len(self.table1), len(self.table2), 'Row lengths do not match.')
+        for row1, row2 in zip(self.table1, self.table2):
+            self.assertEqual(len(row1), len(row2), 'Column lengths do not match.')
+
+    def test_spans(self):
+        self.assertEqual(self.spans1, self.spans2, "Tables' spans do not match.")
+
+    def test_header(self):
+        self.assertEqual(self.header1, self.header2, "Tables' header flags do not match.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Found a bug while working with `data2rst` and `grid2data` functions.

Given a table like this:
```
+-----+--------+-------+
| 0,0 | 0,1    | 0,2   |
+=====+========+=======+
| 1,0 | 1,1    | 1,2   |
+-----+--------+-------+
| 2,0 | 2,1        2,2 |
|     |                |
+-----+ 3,1        3,2 |
| 3,0 |                |
|     +--------+-------+
| 4,0 | 4,1    | 4,2   |
+-----+--------+-------+
```
When run through `grid2data` and back through `data2rst` the table gets converted to this:
```
+-----+--------+-------+
| 0,0 | 0,1    | 0,2   |
+=====+========+=======+
| 1,0 | 1,1    | 1,2   |
+-----+--------+-------+
| 2,0 | 2,1        2,2 |
|     |                |
+-----| 3,1        3,2 |
| 3,0 |                |
|     +--------+-------+
| 4,0 | 4,1    | 4,2   |
+-----+--------+-------+
```
The border between cell 2,0/3,0, and span 2,1 gets converted from `+` to `|`

When converting this new table with `grid2data` it creates a broken set of `spans` (run`tests/test_rstspan.py` against the original `merge_cells.py` to see this happen.

I've included a fix with `merge_cells.py` that prioritizes `+` when merging cells together.